### PR TITLE
feat: add topical authority graph and related tooling

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+/tiles/*
+  Content-Type: application/x-protobuf
+  Content-Encoding: gzip
+  Cache-Control: public, max-age=31536000, immutable

--- a/data/tag.json
+++ b/data/tag.json
@@ -1,0 +1,19 @@
+{
+  "entities": {
+    "service:bond-cleaning": { "type": "service", "slug": "bond-cleaning", "title": "Bond Cleaning" },
+    "service:spring-cleaning": { "type": "service", "slug": "spring-cleaning", "title": "Spring Cleaning" },
+
+    "suburb:ipswich": { "type": "suburb", "slug": "ipswich", "name": "Ipswich", "postcode": "4305", "state": "QLD" },
+    "suburb:springfield-lakes": { "type": "suburb", "slug": "springfield-lakes", "name": "Springfield Lakes", "postcode": "4300", "state": "QLD" },
+
+    "topic:agent-standards": { "type": "topic", "slug": "agent-standards", "title": "What Agents Expect" },
+    "topic:bond-checklist": { "type": "topic", "slug": "bond-checklist", "title": "Bond Cleaning Checklist" }
+  },
+  "edges": [
+    ["service:bond-cleaning", "suburb:ipswich", "covers"],
+    ["service:bond-cleaning", "suburb:springfield-lakes", "covers"],
+    ["service:bond-cleaning", "topic:bond-checklist", "explains"],
+    ["topic:agent-standards", "service:bond-cleaning", "applies-to"],
+    ["suburb:ipswich", "suburb:springfield-lakes", "nearby"]
+  ]
+}

--- a/layouts/ServiceLayout.astro
+++ b/layouts/ServiceLayout.astro
@@ -111,6 +111,6 @@ const pageDescription = `${service.description} Servicing ${suburb.name} and nea
   <!-- Acceptance criteria and related services -->
   <section class="max-w-6xl mx-auto px-4">
   <AcceptanceSlice suburbName={suburb.name} />
-  <RelatedLinks service={service.slug} suburbSlug={suburb.slug} title="Related services" count={3} />
+  <RelatedLinks {service} {suburb} />
   </section>
 </MainLayout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@astrojs/netlify": "^6.4.1",
+        "haversine-distance": "^1.2.1",
         "playwright": "^1.55.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -11644,6 +11645,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/haversine-distance": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/haversine-distance/-/haversine-distance-1.2.4.tgz",
+      "integrity": "sha512-8MHQBQXR7GXZJIvitCf/ux+gwLtWOxmXNNz5dReG+jJbuvaEoj6QIXlaIO3cPr433BFWM4jececJaLYpwxnZhg==",
+      "license": "MIT"
     },
     "node_modules/he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   "@astrojs/netlify": "^6.4.1",
     "playwright": "^1.55.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "haversine-distance": "^1.2.1"
   }
 }

--- a/scripts/audit-content.mjs
+++ b/scripts/audit-content.mjs
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DIST = 'dist';
+let fail = false;
+
+function walk(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const fp = path.join(dir, name);
+    const st = fs.statSync(fp);
+    if (st.isDirectory()) walk(fp);
+    else if (name.endsWith('.html')) check(fp);
+  }
+}
+
+function check(file) {
+  const html = fs.readFileSync(file, 'utf8');
+  const mainMatch = html.match(/<main[\s\S]*?>[\s\S]*?<\/main>/i);
+  const main = mainMatch ? mainMatch[0] : '';
+  const text = main.replace(/<[^>]*>/g, ' ');
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const links = (main.match(/<a\s+[^>]*href=['"][^'"]+['"][^>]*>/gi) || []).length;
+  if (words < 700 || links < 3) {
+    console.error('[audit]', file, { words, links });
+    fail = true;
+  }
+}
+
+walk(DIST);
+if (fail) process.exit(1);

--- a/scripts/build-related-links.mjs
+++ b/scripts/build-related-links.mjs
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import tag from '../data/tag.json' assert { type: 'json' };
+
+const neighbors = (slug) =>
+  tag.edges
+    .filter(([a, b, rel]) => rel === 'nearby' && (a === `suburb:${slug}` || b === `suburb:${slug}`))
+    .map(([a, b]) => (a.endsWith(slug) ? b : a).replace('suburb:', ''));
+
+const out = {};
+for (const [id, e] of Object.entries(tag.entities)) {
+  if (e.type !== 'suburb') continue;
+  out[e.slug] = neighbors(e.slug).slice(0, 4);
+}
+fs.mkdirSync('src/data', { recursive: true });
+fs.writeFileSync('src/data/related-links.json', JSON.stringify(out, null, 2));

--- a/scripts/build-tiles.mjs
+++ b/scripts/build-tiles.mjs
@@ -1,0 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OUT_DIR = 'public/tiles';
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+// Placeholder for vector tile build step.
+// Integrate real tile generation here using your suburb GeoJSON.
+console.log('[build-tiles] placeholder - no tiles generated');

--- a/scripts/gen-pages.mjs
+++ b/scripts/gen-pages.mjs
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import tag from '../data/tag.json' assert { type: 'json' };
+
+const OUT_DIR = 'src/pages/services';
+
+for (const [id, e] of Object.entries(tag.entities)) {
+  if (e.type !== 'suburb') continue;
+
+  for (const [sid, s] of Object.entries(tag.entities)) {
+    if (s.type !== 'service') continue;
+
+    const covers = tag.edges.some(([a, b, rel]) => a === `service:${s.slug}` && b === `suburb:${e.slug}` && rel === 'covers');
+    if (!covers) continue;
+
+    const dir = path.join(OUT_DIR, s.slug, e.slug);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'index.astro'),
+      `---\n// Auto-generated from TAG\nimport Layout from '../../../layouts/SuburbService.astro';\nconst service = ${JSON.stringify(s)};\nconst suburb = ${JSON.stringify(e)};\n---\n<Layout {service} {suburb} />\n`
+    );
+  }
+}

--- a/src/components/RelatedLinks.astro
+++ b/src/components/RelatedLinks.astro
@@ -1,33 +1,15 @@
 ---
-import { getRelatedServiceLinks } from '~/utils/internalLinks';
-import { prioritiseByGrid } from '~/utils/prioritiseByGrid.js';
-const {
-  service = 'bond-cleaning',
-  suburbSlug = '',
-  count = 3,           // align to helper default
-  includeSelf = false, // keep OFF for "related" blocks
-  title = 'Related'
-} = Astro.props;
-
-let links = getRelatedServiceLinks({ service, suburbSlug, count, includeSelf, prioritiseByGrid });
-if (links.length < count) {
-  // As a fallback, include the current suburb at the end to meet the cap.
-  const filled = getRelatedServiceLinks({ service, suburbSlug, count, includeSelf: true, prioritiseByGrid });
-  // keep unique order but prefer the original ordering
-  const seen = new Set();
-  links = [...links, ...filled].filter((l) => {
-    const key = l.href;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  }).slice(0, count);
-}
+import links from "../data/related-links.json";
+const { suburb, service } = Astro.props;
+const n = links[suburb.slug] ?? [];
 ---
-<section role="region" class="related-links mt-6" data-relblock aria-label={`${title} navigation`}>
-  <h2 id="related-links-title" class="text-lg font-semibold mb-2">{title}</h2>
-  <ul class="space-y-2">
-    {links.map((l) => (
-      <li><a href={l.href} class="text-blue-700 underline hover:no-underline">{l.label}</a></li>
-    ))}
-  </ul>
-</section>
+{n.length ? (
+  <aside aria-label="Related links" class="mt-10">
+    <h2 class="text-lg font-semibold">Nearby suburbs we serve</h2>
+    <ul class="mt-3 grid grid-cols-2 gap-2">
+      {n.map(slug => (
+        <li><a class="text-fresh-sky underline" href={`/services/${service.slug}/${slug}/`}>{slug.replaceAll("-", " ")}</a></li>
+      ))}
+    </ul>
+  </aside>
+) : null}

--- a/src/data/related-links.json
+++ b/src/data/related-links.json
@@ -1,0 +1,8 @@
+{
+  "ipswich": [
+    "springfield-lakes"
+  ],
+  "springfield-lakes": [
+    "ipswich"
+  ]
+}

--- a/src/islands/SuburbMap.ts
+++ b/src/islands/SuburbMap.ts
@@ -1,0 +1,5 @@
+export default function SuburbMap(el: HTMLElement, { service, suburb }: { service: string; suburb: string }) {
+  // Placeholder for MapLibre map integration.
+  // Integrate maplibre-gl and vector tiles in real implementation.
+  console.log('Init map for', service, suburb, el);
+}

--- a/src/layouts/ServiceLayout.astro
+++ b/src/layouts/ServiceLayout.astro
@@ -111,6 +111,6 @@ const pageDescription = `${service.description} Servicing ${suburb.name} and nea
   <!-- Acceptance criteria and related services -->
   <section class="max-w-6xl mx-auto px-4">
   <AcceptanceSlice suburbName={suburb.name} />
-  <RelatedLinks service={service.slug} suburbSlug={suburb.slug} title="Related services" count={3} />
+  <RelatedLinks {service} {suburb} />
   </section>
 </MainLayout>

--- a/src/layouts/SuburbService.astro
+++ b/src/layouts/SuburbService.astro
@@ -1,0 +1,6 @@
+---
+import ServiceLayout from './ServiceLayout.astro';
+const { service, suburb } = Astro.props;
+const title = `${service.title} in ${suburb.name}`;
+---
+<ServiceLayout {service} {suburb} title={title} />

--- a/src/lib/quote.ts
+++ b/src/lib/quote.ts
@@ -1,0 +1,9 @@
+import h from 'haversine-distance';
+
+export function quote({ base, depot, to, flags }: any) {
+  const km = h(depot, to) / 1000;
+  const travel = km < 10 ? 0 : km < 25 ? 10 : 25;
+  const parking = flags?.parkingHard ? 15 : 0;
+  const band = base + travel + parking;
+  return { min: band - 20, max: band + 20, km };
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,42 @@
+export function graph({ biz, service, suburb, pageUrl }: any) {
+  const base = 'https://onen-done.au/#';
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@id': base + 'org',
+        '@type': ['Organization', 'LocalBusiness'],
+        name: biz.name,
+        url: 'https://onen-done.au/',
+        logo: 'https://onen-done.au/logo.png',
+        areaServed: { '@id': `${base}suburb-${suburb.slug}` }
+      },
+      {
+        '@id': `${base}service-${service.slug}`,
+        '@type': 'Service',
+        name: service.title,
+        provider: { '@id': base + 'org' },
+        serviceArea: { '@id': `${base}suburb-${suburb.slug}` }
+      },
+      {
+        '@id': `${base}suburb-${suburb.slug}`,
+        '@type': 'Place',
+        name: suburb.name,
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: suburb.name,
+          postalCode: suburb.postcode,
+          addressRegion: suburb.state,
+          addressCountry: 'AU'
+        }
+      },
+      {
+        '@id': base + 'webpage',
+        '@type': 'WebPage',
+        url: pageUrl,
+        isPartOf: { '@id': base + 'org' },
+        about: [{ '@id': `${base}service-${service.slug}` }, { '@id': `${base}suburb-${suburb.slug}` }]
+      }
+    ]
+  };
+}


### PR DESCRIPTION
## Summary
- add TAG data source and scripts to generate service–suburb pages and related-link data
- expose JSON-LD graph and quote utilities
- wire new RelatedLinks component and headers for future map tiles

## Testing
- `node scripts/gen-pages.mjs`
- `node scripts/build-related-links.mjs`
- `node scripts/build-tiles.mjs`
- `npm test` *(fails: No tests found)*
- `node scripts/audit-content.mjs` *(fails: ENOENT: no such file or directory, scandir 'dist')*


------
https://chatgpt.com/codex/tasks/task_e_68ad91a1e16c832e944b662fa4d5bafe